### PR TITLE
Establish local state and mutual CI practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,23 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  pinned-ssg:
+    name: Build with pinned SSG
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Checkout
+      - name: Checkout blog
         uses: actions/checkout@v4
 
       - name: Setup Node
@@ -24,3 +32,41 @@ jobs:
 
       - name: Build blog
         run: npm run blog:check
+
+  current-ssg:
+    name: Build with current SSG main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout blog
+        uses: actions/checkout@v4
+        with:
+          path: blog
+
+      - name: Checkout SSG
+        uses: actions/checkout@v4
+        with:
+          repository: rajp152k/ssg
+          ref: main
+          path: ssg
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            blog/package-lock.json
+            ssg/package-lock.json
+
+      - name: Install blog dependencies
+        working-directory: blog
+        run: npm ci
+
+      - name: Install SSG dependencies
+        working-directory: ssg
+        run: npm ci
+
+      - name: Test current SSG against blog
+        working-directory: blog
+        run: ../ssg/node_modules/.bin/tsx ../ssg/src/cli.ts build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 public/
 dist/
+
+anvil/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,19 @@ Project commands:
 /hart-improve [optional focus]
 ```
 
+## Repository and CI practice
+
+- Never mutate `master` directly. Create a focused local branch, commit there, push it, and merge only through a pull request after required CI checks pass.
+- A merge to `master` is the deployment boundary and must trigger the complete deployment pipeline.
+- Keep temporary feature state under `anvil/`. The directory is local, ignored by Git, and must not be used by blog posts or treated as durable state.
+- The blog and SSG are developed together but remain independently versioned repositories.
+- Blog CI must build with the lockfile-pinned SSG and check compatibility with the current SSG `main` branch.
+- SSG CI must retain focused fixtures for unit tests and dogfood the generator by building the blog's `master` branch with the exact SSG revision under test.
+- Cross-repository checks supplement local tests; they do not replace precise fixtures or regression tests.
+- Pin durable dependencies by lockfile or commit. Treat mutable branch checkouts as compatibility checks, not reproducible inputs.
+- CI caches may reduce work but must never be required for correctness. A clean checkout must be sufficient to run validation and builds.
+- Use `[skip ci]` only for changes that cannot affect validation, builds, generated artifacts, or deployment behavior.
+
 ## Post format
 
 Posts live under:


### PR DESCRIPTION
## Summary
- reserve ignored `anvil/` workspace state
- verify the blog with pinned and current SSG revisions
- document branch, CI, and mutual-development practices

## Validation
- `npm run blog:check`
- current local SSG builds the blog