### PR TITLE
Upgrade GitHub Actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout blog
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -39,19 +39,19 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout blog
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: blog
 
       - name: Checkout SSG
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: rajp152k/ssg
           ref: main
           path: ssg
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy-readme.yml
+++ b/.github/workflows/deploy-readme.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -31,10 +31,10 @@ jobs:
         run: npm run blog:check
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: public
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,9 @@ Project commands:
 
 ## Repository and CI practice
 
-- Never mutate `master` directly. Create a focused local branch, commit there, push it, and merge only through a pull request after required CI checks pass.
+- Never mutate `master` directly. Create a focused local branch, commit there, push it, and open a pull request.
+- Observe every required pull-request check through completion. Merge only after all checks succeed; investigate failures instead of bypassing or prematurely merging around them.
+- After merging, observe the complete `master` validation and deployment pipelines through completion and report any warnings or failures.
 - A merge to `master` is the deployment boundary and must trigger the complete deployment pipeline.
 - Keep temporary feature state under `anvil/`. The directory is local, ignored by Git, and must not be used by blog posts or treated as durable state.
 - The blog and SSG are developed together but remain independently versioned repositories.


### PR DESCRIPTION
## Summary
- upgrade CI and Pages actions to Node 24-backed versions
- require observing PR and post-merge pipelines in repository practice

## Validation
- workflow diffs pass whitespace validation