### PR TITLE
Use supported display math delimiters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Guidance for writing and editing posts in this repository.
   - explain what the model captures and what it ignores;
   - avoid unnecessary formalism.
 - Use assistive diagrams, charts, tables, and mathematical equations whenever they improve compression, comparison, or recall.
+- Delimit display mathematics with `$$` on separate lines. Do not use `\[` and `\]`; the current Markdown and MathJax pipeline does not render those delimiters reliably.
 - When making foundational claims, cite fundamental literature wherever possible: papers, books, specifications, standards, primary documentation, or historically important implementations.
 - Prefer citations that anchor concepts, not citations used as decoration.
 - When discussing software, prefer concrete artifacts: types, interfaces, state machines, data flow, build graphs, protocols, tests, and source-level behavior.

--- a/content/posts/formulating-carr/canvas.md
+++ b/content/posts/formulating-carr/canvas.md
@@ -93,9 +93,9 @@ C.A.R.R. should first identify the strongest charitable form of the argument. It
 
 This distinction matters:
 
-\[
+$$
 rigorous\ challenge \ne automatic\ disagreement
-\]
+$$
 
 The role succeeds when it changes the model, sharpens its boundary, produces a decisive test, or establishes that the argument survived serious pressure. Merely sounding unconvinced is theatre.
 


### PR DESCRIPTION
## Summary
- replace the broken `\[ ... \]` equation delimiters in Formulating C.A.R.R.
- document `$$` as the required display-math convention

## Validation
- `npm run blog:build:local`