### PR TITLE
Use a Solarized Light background

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -113,7 +113,7 @@
       .posts-table th {
         position: sticky;
         top: 0;
-        background: #fff;
+        background: var(--tabloid-bg);
         border-bottom: 2px solid #000;
         text-transform: uppercase;
         letter-spacing: 0.04em;

--- a/templates/themes/light.css
+++ b/templates/themes/light.css
@@ -1,12 +1,12 @@
 :root {
   color-scheme: light;
-  --tabloid-bg: #ffffff;
+  --tabloid-bg: #fdf6e3;
   --tabloid-fg: #000000;
   --tabloid-muted: #3f3f3f;
   --tabloid-border: #000000;
   --tabloid-rule: #000000;
-  --tabloid-panel: #ffffff;
-  --tabloid-soft: #f5f5f5;
+  --tabloid-panel: #fdf6e3;
+  --tabloid-soft: #eee8d5;
 }
 
 html,


### PR DESCRIPTION
## Summary\n- replace pure-white light-theme surfaces with Solarized Light base3\n- use Solarized Light base2 for subdued surfaces\n- keep the index table header aligned with the page background\n\n## Validation\n- npm run blog:build:local